### PR TITLE
Log level enhancements

### DIFF
--- a/mac_services/mlme_sap/SYNC.cc
+++ b/mac_services/mlme_sap/SYNC.cc
@@ -56,7 +56,7 @@ void SYNC::request(request_parameters& params) {
     dsme.getPHY_PIB().phyCurrentChannel = params.channelNumber;
     dsme.getMAC_PIB().macSyncParentShortAddress = params.syncParentShortAddress;
     dsme.getMAC_PIB().macSyncParentSdIndex = params.syncParentSdIndex;
-    LOG_ERROR("SYNC " << params.syncParentSdIndex << " " << params.syncParentShortAddress);
+    LOG_INFO("SYNC " << params.syncParentSdIndex << " " << params.syncParentShortAddress);
     dsme.startTrackingBeacons();
 }
 


### PR DESCRIPTION
Dumping ERROR messages (eg. in RIOT using \[^1]) makes SYNC messages show. While they are much rarer than the rest of the INFO level output, they're still not errors. So, let's either demote them to info or introduce more fine grained logging. Either way, chances are there are other similar errors that should be rolled up in this PR.

It'd be tempting to go a step further and make it print the output in hex, eg. using

```c++
LOG_INFO("SYNC " << params.syncParentSdIndex << " " <<  std::format("{:#04x}", params.syncParentShortAddress));
```

but the `#include <format>` header would at least require c++23 and we're currently at 14. (Yes there is `<< std::hex << params.syncParentShortAddress`, but I loathe that mechanism's statefulness).

<details><summary>[^1]: Enabling error logging in RIOT</summary>

```patch
diff --git a/pkg/opendsme/include/opendsme/dsme_platform.h b/pkg/opendsme/include/opendsme/dsme_platform.h
index cfaa3a547f..08dfcabbfe 100644
--- a/pkg/opendsme/include/opendsme/dsme_platform.h
+++ b/pkg/opendsme/include/opendsme/dsme_platform.h
@@ -23,0 +24 @@
+#include <iostream>
@@ -36 +37 @@ extern "C" {
-#define LOG_ERROR(x)
+#define LOG_ERROR(x) std::cout << x << std::endl
```

</details>